### PR TITLE
Fix loop initial declaration used outside C99 mode.

### DIFF
--- a/ext/vmstat/vmstat.c
+++ b/ext/vmstat/vmstat.c
@@ -103,7 +103,8 @@ VALUE method_cpu(VALUE self) {
     PROCESSOR_CPU_LOAD_INFO, &numCPUsU, &cpuInfo, &numCpuInfo);
 
   if(err == KERN_SUCCESS) {
-    for(unsigned i = 0U; i < numCPUsU; ++i) {
+    unsigned i;
+    for(i = 0U; i < numCPUsU; ++i) {
       VALUE cpu = rb_hash_new();
       int pos = CPU_STATE_MAX * i;
       rb_hash_aset(cpu, SYM_USER, ULL2NUM(cpuInfo[pos + CPU_STATE_USER]));


### PR DESCRIPTION
When I trying to install the gem using "gem install vmstat" it gives me:

```
Fetching: vmstat-0.1.0.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing vmstat:
    ERROR: Failed to build gem native extension.

        /Users/pecarrico/.rbenv/versions/1.9.3-p194/bin/ruby extconf.rb
creating Makefile

make
compiling vmstat.c
vmstat.c: In function ‘method_cpu’:
vmstat.c:106: error: ‘for’ loop initial declaration used outside C99 mode
make: *** [vmstat.o] Error 1


Gem files will remain installed in /Users/pecarrico/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/vmstat-0.1.0 for inspection.
Results logged to /Users/pecarrico/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/vmstat-0.1.0/ext/vmstat/gem_make.out
```

I'm running Lion and gcc version follows.
gcc --version
i686-apple-darwin11-gcc-4.2.1 (GCC) 4.2.1 (Apple Inc. build 5666) (dot 3)

Declaring the variable outside the for loop makes it C90 compatible.
