### PR TITLE
Added support for MemAvailable

### DIFF
--- a/lib/vmstat/memory.rb
+++ b/lib/vmstat/memory.rb
@@ -15,11 +15,11 @@ module Vmstat
   # @attr [Fixnum] pageouts
   #   The number of pageouts.
   class Memory < Struct.new(:pagesize, :wired, :active, :inactive, :free,
-                            :pageins, :pageouts)
+                            :pageins, :pageouts, :available)
     # Calculate the wired bytes based of the wired pages.
     # @return [Fixnum] wired bytes
     def wired_bytes
-      wired *  pagesize
+      wired * pagesize
     end
 
     # Calculate the active bytes based of the active pages.
@@ -40,10 +40,16 @@ module Vmstat
       free * pagesize
     end
 
+    # Calculate the available bytes based of the active pages.
+    # @return [Fixnum] active bytes
+    def available_bytes
+      available * pagesize
+    end
+
     # Calculate the total bytes based of all pages
     # @return [Fixnum] total bytes
     def total_bytes
-      (wired + active + inactive + free) * pagesize  
+      (wired + active + inactive + free) * pagesize
     end
   end
 end

--- a/lib/vmstat/procfs.rb
+++ b/lib/vmstat/procfs.rb
@@ -46,16 +46,17 @@ module Vmstat
     def memory
       @pagesize ||= Vmstat.pagesize
 
-      total = free = active = inactive = pageins = pageouts = 0
+      total = free = active = inactive = pageins = pageouts = available = 0
       procfs_file("meminfo") do |file|
         content = file.read(2048) # the requested information is in the first bytes
 
-        content.scan(/(\w+):\s+(\d+) kB/) do |name, kbytes| 
+        content.scan(/(\w+):\s+(\d+) kB/) do |name, kbytes|
           pages = (kbytes.to_i * 1024) / @pagesize
 
           case name
             when "MemTotal" then total = pages
             when "MemFree" then free = pages
+            when "MemAvailable" then available = pages
             when "Active" then active = pages
             when "Inactive" then inactive = pages
           end
@@ -74,8 +75,7 @@ module Vmstat
         end
       end
 
-      Memory.new @pagesize, total-free-active-inactive, active, inactive, free,
-                 pageins, pageouts
+      Memory.new @pagesize, total-free-active-inactive, active, inactive, free, pageins, pageouts, available
     end
 
     # Fetches the information for all available network devices.
@@ -91,8 +91,8 @@ module Vmstat
             when /^lo/  then NetworkInterface::LOOPBACK_TYPE
           end
 
-          netifcs << NetworkInterface.new(columns[0].to_sym, columns[1].to_i, 
-                                          columns[3].to_i,   columns[4].to_i, 
+          netifcs << NetworkInterface.new(columns[0].to_sym, columns[1].to_i,
+                                          columns[3].to_i,   columns[4].to_i,
                                           columns[9].to_i,   columns[11].to_i,
                                           type)
         end
@@ -107,7 +107,7 @@ module Vmstat
 
       procfs_file("self", "stat") do |file|
         data = file.read.split(/ /)
-        Task.new(data[22].to_i / @pagesize, data[23].to_i, 
+        Task.new(data[22].to_i / @pagesize, data[23].to_i,
                  data[13].to_i * 1000, data[14].to_i * 1000)
       end
     end


### PR DESCRIPTION
Happily using vmstat, but I was missing the MemAvailable metric. As MemFree is typically a low value, because Linux fills free memory with the page cache. This make MemAvailable the key metric, at least when using Linux. (Don't know how BSD and derivatives behave)