### PR TITLE
Remove fsevent from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in vmstat.gemspec
 gemspec
-
-gem 'rb-fsevent', '~> 0.9.1' if RUBY_PLATFORM =~ /darwin/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,4 +71,4 @@ DEPENDENCIES
   vmstat!
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,4 +71,4 @@ DEPENDENCIES
   vmstat!
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
I think this solves the problem I was having earlier when fighting with the Gemfile.lock conflicts. In your Gemfile you have a dependency on rb-fsevent 0.9 for Darwin which this PR removes.

The reasons are first, as far as I can tell you aren't actually using this library directly, so I'm not sure why it's there. After removing it the specs still pass.

And second, the current Gemfile creates a versioning issue because you're requiring version 0.9.1, but `rspec-guard` has a dependency on the `guard` library, which in turn has a dependency on the `listen` library, which ultimately has a dependency on `fs-event` version 0.10.3+:

https://github.com/guard/listen/blob/master/listen.gemspec#L27

So, I vote to remove it.