### PR TITLE
Delete duplicate definition of `LinuxMemory`

### DIFF
--- a/lib/vmstat/memory.rb
+++ b/lib/vmstat/memory.rb
@@ -46,17 +46,4 @@ module Vmstat
       (wired + active + inactive + free) * pagesize
     end
   end
-
-  # @attr [Fixnum] available
-  #   The estimated available memory (linux)
-  #   See: https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773
-  class LinuxMemory < Memory
-    attr_accessor :available
-
-    # Calculate the available bytes based of the active pages.
-    # @return [Fixnum] active bytes
-    def available_bytes
-      available * pagesize
-    end
-  end
 end


### PR DESCRIPTION
I think this was added accidentally in 5c13458dfbb0a2297d4a358fd157fdd574ba76c3. It generates the following warnings in our app:

```
vmstat-2.3.1/lib/vmstat/memory.rb:54: warning: method redefined; discarding old available
vmstat-2.3.1/lib/vmstat/memory.rb:54: warning: method redefined; discarding old available=
vmstat-2.3.1/lib/vmstat/memory.rb:58: warning: method redefined; discarding old available_bytes
vmstat-2.3.1/lib/vmstat/linux_memory.rb:9: warning: previous definition of available_bytes was here
```